### PR TITLE
local dev infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+# settings
+.env
+
+# generated
 assets/
 cards.txt

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,27 @@
+# Load variables from .env file (if exists).
+-include .env
+
 install_pre_commit_hooks:
 	pre-commit install
 
 build:
 	go build ./... > /dev/null
 
-tests:
+tests: infra-start run-tests
+
+run-tests:
 	go test ./... -race -count=1 -timeout 30s 
 
 cleanup:
 	go mod tidy
+
+# Ollama language model with default fallback if not set.
+OLLAMA_LLM := $(or $(OLLAMA_LLM), "aya-expanse:8b")
+
+infra-start:
+	docker volume create ollama
+	docker compose up --detach
+	docker exec ollama ollama run $(OLLAMA_LLM)
+
+infra-stop:
+	docker compose down

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  ollama:
+    image: ollama/ollama:0.5.4
+    container_name: ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama:/root/.ollama
+    
+volumes:
+  ollama:
+    external: true


### PR DESCRIPTION
To set up local development infrastructure:
- [x] Add a docker-compose file describing LLM service https://hub.docker.com/r/ollama/ollama
- [x] Add a job that starts this file to the Makefile.
- [x] Run this job before running tests in local CI by git pre-commit hook https://pre-commit.com/